### PR TITLE
Fix Unicode encoding errors

### DIFF
--- a/sse-encoder.go
+++ b/sse-encoder.go
@@ -18,7 +18,7 @@ import (
 // W3C Working Draft 29 October 2009
 // http://www.w3.org/TR/2009/WD-eventsource-20091029/
 
-const ContentType = "text/event-stream"
+const ContentType = "text/event-stream;charset=utf-8"
 
 var contentType = []string{ContentType}
 var noCache = []string{"no-cache"}

--- a/sse_test.go
+++ b/sse_test.go
@@ -196,7 +196,7 @@ func TestRenderSSE(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, w.Body.String(), "event:msg\ndata:hi! how are you?\n\n")
-	assert.Equal(t, w.Header().Get("Content-Type"), "text/event-stream")
+	assert.Equal(t, w.Header().Get("Content-Type"), "text/event-stream;charset=utf-8")
 	assert.Equal(t, w.Header().Get("Cache-Control"), "no-cache")
 }
 


### PR DESCRIPTION
If don't add "charset=utf-8" browsers can't accurate encoding of Unicode characters