### PR TITLE
Removing duplicated newline on Render 

### DIFF
--- a/sse-encoder.go
+++ b/sse-encoder.go
@@ -78,7 +78,6 @@ func writeData(w stringWriter, data interface{}) error {
 		if err != nil {
 			return err
 		}
-		w.WriteString("\n")
 	default:
 		dataReplacer.WriteString(w, fmt.Sprint(data))
 		w.WriteString("\n\n")


### PR DESCRIPTION
According to the `encoding/json` documentation, the `Encode` function already adds a newline to the `Writer`

```
// Encode writes the JSON encoding of v to the stream,
// followed by a newline character.
//
// See the documentation for Marshal for details about the
// conversion of Go values to JSON.
func (enc *Encoder) Encode(v interface{}) error {
...
```

making the following line from `sse-encoder.go` unnecessary

```
w.WriteString("\n")
```