### PR TITLE
Fix event retry field logic.

### DIFF
--- a/sse-decoder.go
+++ b/sse-decoder.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"strconv"
 )
 
 type decoder struct {
@@ -98,7 +99,11 @@ func (d *decoder) decode(r io.Reader) ([]Event, error) {
 			// If the field value consists of only characters in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9),
 			// then interpret the field value as an integer in base ten, and set the event stream's reconnection time to that integer.
 			// Otherwise, ignore the field.
-			currentEvent.Id = string(value)
+			valueRetryint, ise := strconv.Atoi(string(value))
+			if ise == nil {
+				currentEvent.Retry = uint(valueRetryint)
+			}
+
 		case "data":
 			// Append the field value to the data buffer,
 			dataBuffer.Write(value)


### PR DESCRIPTION
I think we can not changed the encode data , As there maybe some meaning in it.
Now the code , changed the id, and retry field .

Fix before:
![image](https://github.com/user-attachments/assets/58389abf-d775-4314-8966-e23d5ed9bdb9)
![image](https://github.com/user-attachments/assets/2b7da152-2346-4a43-85d1-a7d2d92f0307)


Fix after:
![image](https://github.com/user-attachments/assets/191b499b-8a2d-4c13-8007-fe35a197ed6d)
![image](https://github.com/user-attachments/assets/f51e8858-3be2-405e-89de-71cbadf3671c)
