### PR TITLE
feat: Encode function can optimize byte array handling

### DIFF
--- a/sse-encoder.go
+++ b/sse-encoder.go
@@ -72,6 +72,14 @@ func writeRetry(w stringWriter, retry uint) {
 
 func writeData(w stringWriter, data interface{}) error {
 	w.WriteString("data:")
+
+	bData, ok := data.([]byte)
+	if ok {
+		dataReplacer.WriteString(w, string(bData))
+		w.WriteString("\n\n")
+		return nil
+	}
+
 	switch kindOfData(data) {
 	case reflect.Struct, reflect.Slice, reflect.Map:
 		err := json.NewEncoder(w).Encode(data)


### PR DESCRIPTION

In scenarios where byte array JSON messages are forwarded (e.g., from MQ), the previous approach required unmarshalling into an object before encoding for SSE.

The updated logic allows []byte to be passed directly, simplifying message forwarding and reducing unnecessary conversions.

```go
// before
byteData := messageFromMQ()
data := make(map[string]any)
json.Unmarshal(byteData, &data)
sse.Encode(new(bytes.Buffer), sse.Event{
	Data: data,
})

// after
byteData := messageFromMQ()
sse.Encode(new(bytes.Buffer), sse.Event{
	Data: byteData,
})
```