### PR TITLE
fix: add space after colon in SSE field names per W3C spec

### DIFF
--- a/sse-encoder.go
+++ b/sse-encoder.go
@@ -30,7 +30,7 @@ var fieldReplacer = strings.NewReplacer(
 	"\r", "\\r")
 
 var dataReplacer = strings.NewReplacer(
-	"\n", "\ndata:",
+	"\n", "\ndata: ",
 	"\r", "\\r")
 
 type Event struct {
@@ -50,7 +50,7 @@ func Encode(writer io.Writer, event Event) error {
 
 func writeId(w stringWriter, id string) {
 	if len(id) > 0 {
-		_, _ = w.WriteString("id:")
+		_, _ = w.WriteString("id: ")
 		_, _ = fieldReplacer.WriteString(w, id)
 		_, _ = w.WriteString("\n")
 	}
@@ -58,7 +58,7 @@ func writeId(w stringWriter, id string) {
 
 func writeEvent(w stringWriter, event string) {
 	if len(event) > 0 {
-		_, _ = w.WriteString("event:")
+		_, _ = w.WriteString("event: ")
 		_, _ = fieldReplacer.WriteString(w, event)
 		_, _ = w.WriteString("\n")
 	}
@@ -66,14 +66,14 @@ func writeEvent(w stringWriter, event string) {
 
 func writeRetry(w stringWriter, retry uint) {
 	if retry > 0 {
-		_, _ = w.WriteString("retry:")
+		_, _ = w.WriteString("retry: ")
 		_, _ = w.WriteString(strconv.FormatUint(uint64(retry), 10))
 		_, _ = w.WriteString("\n")
 	}
 }
 
 func writeData(w stringWriter, data interface{}) error {
-	_, _ = w.WriteString("data:")
+	_, _ = w.WriteString("data: ")
 
 	bData, ok := data.([]byte)
 	if ok {

--- a/sse_test.go
+++ b/sse_test.go
@@ -26,13 +26,10 @@ func TestEncodeOnlyData(t *testing.T) {
 	}
 	err := Encode(w, event)
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(),
-		`data:junk
-data:
-data:jk
-data:id:fake
-
-`)
+	// Per SSE spec (W3C), fields should have a space after the colon.
+	// Empty data lines become "data: " (field name + colon + space, no value).
+	expected := "data: junk\ndata: \ndata: jk\ndata: id:fake\n\n"
+	assert.Equal(t, expected, w.String())
 
 	decoded, _ := Decode(w)
 	assert.Equal(t, "message", decoded[0].Event)
@@ -47,14 +44,8 @@ func TestEncodeWithEvent(t *testing.T) {
 	}
 	err := Encode(w, event)
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(),
-		`event:t\n:<>\r	est
-data:junk
-data:
-data:jk
-data:id:fake
-
-`)
+	expected := "event: t\\n:<>\\r\test\ndata: junk\ndata: \ndata: jk\ndata: id:fake\n\n"
+	assert.Equal(t, expected, w.String())
 
 	decoded, _ := Decode(w)
 	assert.Equal(t, "t\\n:<>\\r\test", decoded[0].Event)
@@ -68,14 +59,8 @@ func TestEncodeWithId(t *testing.T) {
 		Data: "junk\n\njk\nid:fa\rke",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(),
-		`id:t\n:<>\r	est
-data:junk
-data:
-data:jk
-data:id:fa\rke
-
-`)
+	expected := "id: t\\n:<>\\r\test\ndata: junk\ndata: \ndata: jk\ndata: id:fa\\rke\n\n"
+	assert.Equal(t, expected, w.String())
 }
 
 func TestEncodeWithRetry(t *testing.T) {
@@ -85,15 +70,8 @@ func TestEncodeWithRetry(t *testing.T) {
 		Data:  "junk\n\njk\nid:fake\n",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(),
-		`retry:11
-data:junk
-data:
-data:jk
-data:id:fake
-data:
-
-`)
+	expected := "retry: 11\ndata: junk\ndata: \ndata: jk\ndata: id:fake\ndata: \n\n"
+	assert.Equal(t, expected, w.String())
 }
 
 func TestEncodeWithEverything(t *testing.T) {
@@ -105,7 +83,7 @@ func TestEncodeWithEverything(t *testing.T) {
 		Data:  "some data",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "id:12345\nevent:abc\nretry:10\ndata:some data\n\n")
+	assert.Equal(t, w.String(), "id: 12345\nevent: abc\nretry: 10\ndata: some data\n\n")
 }
 
 func TestEncodeMap(t *testing.T) {
@@ -118,7 +96,7 @@ func TestEncodeMap(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:a map\ndata:{\"bar\":\"id: 2\",\"foo\":\"b\\n\\rar\"}\n\n")
+	assert.Equal(t, w.String(), "event: a map\ndata: {\"bar\":\"id: 2\",\"foo\":\"b\\n\\rar\"}\n\n")
 }
 
 func TestEncodeSlice(t *testing.T) {
@@ -128,7 +106,7 @@ func TestEncodeSlice(t *testing.T) {
 		Data:  []interface{}{1, "text", map[string]interface{}{testFooKey: testBarKey}},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:a slice\ndata:[1,\"text\",{\"foo\":\"bar\"}]\n\n")
+	assert.Equal(t, w.String(), "event: a slice\ndata: [1,\"text\",{\"foo\":\"bar\"}]\n\n")
 }
 
 func TestEncodeStruct(t *testing.T) {
@@ -143,7 +121,7 @@ func TestEncodeStruct(t *testing.T) {
 		Data:  myStruct,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:a struct\ndata:{\"A\":1,\"value\":\"number\"}\n\n")
+	assert.Equal(t, w.String(), "event: a struct\ndata: {\"A\":1,\"value\":\"number\"}\n\n")
 
 	w.Reset()
 	err = Encode(w, Event{
@@ -151,7 +129,7 @@ func TestEncodeStruct(t *testing.T) {
 		Data:  &myStruct,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:a struct\ndata:{\"A\":1,\"value\":\"number\"}\n\n")
+	assert.Equal(t, w.String(), "event: a struct\ndata: {\"A\":1,\"value\":\"number\"}\n\n")
 }
 
 func TestEncodeInteger(t *testing.T) {
@@ -161,7 +139,7 @@ func TestEncodeInteger(t *testing.T) {
 		Data:  1,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:an integer\ndata:1\n\n")
+	assert.Equal(t, w.String(), "event: an integer\ndata: 1\n\n")
 }
 
 func TestEncodeFloat(t *testing.T) {
@@ -171,7 +149,7 @@ func TestEncodeFloat(t *testing.T) {
 		Data:  1.5,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, w.String(), "event:Float\ndata:1.5\n\n")
+	assert.Equal(t, w.String(), "event: Float\ndata: 1.5\n\n")
 }
 
 func TestEncodeStream(t *testing.T) {
@@ -193,9 +171,9 @@ func TestEncodeStream(t *testing.T) {
 		Data:  "hi! dude",
 	})
 	assert.Equal(t, w.String(),
-		"event:float\ndata:1.5\n\n"+
-			"id:123\ndata:{\"bar\":\"foo\",\"foo\":\"bar\"}\n\n"+
-			"id:124\nevent:chat\ndata:hi! dude\n\n")
+		"event: float\ndata: 1.5\n\n"+
+			"id: 123\ndata: {\"bar\":\"foo\",\"foo\":\"bar\"}\n\n"+
+			"id: 124\nevent: chat\ndata: hi! dude\n\n")
 }
 
 func TestRenderSSE(t *testing.T) {
@@ -207,9 +185,53 @@ func TestRenderSSE(t *testing.T) {
 	}).Render(w)
 
 	assert.NoError(t, err)
-	assert.Equal(t, w.Body.String(), "event:msg\ndata:hi! how are you?\n\n")
+	assert.Equal(t, w.Body.String(), "event: msg\ndata: hi! how are you?\n\n")
 	assert.Equal(t, w.Header().Get("Content-Type"), "text/event-stream;charset=utf-8")
 	assert.Equal(t, w.Header().Get("Cache-Control"), "no-cache")
+}
+
+// TestSpecCompliance verifies that the encoder produces spec-compliant SSE output
+// per W3C EventSource spec: fields should have a space after the colon.
+func TestSpecCompliance(t *testing.T) {
+	t.Run("data_field_has_space", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		_ = Encode(w, Event{Data: "hello"})
+		assert.Equal(t, "data: hello\n\n", w.String())
+	})
+
+	t.Run("event_field_has_space", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		_ = Encode(w, Event{Event: "update", Data: "x"})
+		assert.Contains(t, w.String(), "event: update\n")
+	})
+
+	t.Run("id_field_has_space", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		_ = Encode(w, Event{Id: "42", Data: "x"})
+		assert.Contains(t, w.String(), "id: 42\n")
+	})
+
+	t.Run("retry_field_has_space", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		_ = Encode(w, Event{Retry: 5, Data: "x"})
+		assert.Contains(t, w.String(), "retry: 5\n")
+	})
+
+	t.Run("multiline_data_continuation_has_space", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		_ = Encode(w, Event{Data: "line1\nline2"})
+		assert.Contains(t, w.String(), "data: line1\ndata: line2\n")
+	})
+
+	t.Run("round_trip_encode_decode", func(t *testing.T) {
+		w := new(bytes.Buffer)
+		event := Event{Event: "test", Id: "1", Data: "hello world"}
+		_ = Encode(w, event)
+		decoded, _ := Decode(w)
+		assert.Equal(t, "test", decoded[0].Event)
+		assert.Equal(t, "1", decoded[0].Id)
+		assert.Equal(t, "hello world", decoded[0].Data)
+	})
 }
 
 func BenchmarkResponseWriter(b *testing.B) {


### PR DESCRIPTION
## Problem

The SSE encoder emits field names without a space after the colon: `data:value` instead of `data: value`. Same for `event:`, `id:`, and `retry:`.

Per the [W3C EventSource spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream), field lines should use the format `field: value` with an optional single space after the colon. The spec's parsing algorithm explicitly strips a leading U+0020 SPACE from the value.

Most browsers tolerate the missing space, but some strict SSE consumers and spec-compliant parsers expect the canonical format. This also makes debugging raw SSE streams harder since `data:hello` is less readable than `data: hello`.

Reported in gin-gonic/gin#4280.

## Fix

- `writeId`: `id:` → `id: `
- `writeEvent`: `event:` → `event: `
- `writeRetry`: `retry:` → `retry: `
- `writeData`: `data:` → `data: `
- `dataReplacer`: `\ndata:` → `\ndata: ` (multiline continuation lines now have the space too)

The decoder already handles both formats — it strips the leading space after the colon on line 77-79 of `sse-decoder.go`. Round-trip encode→decode produces identical results.

## Tests

All 18 existing + new tests pass:
- 12 existing tests updated to match new output format
- 6 new `TestSpecCompliance` sub-tests verifying each field has the space
- Round-trip test confirms encode→decode produces the same event data

```
=== RUN   TestSpecCompliance
=== RUN   TestSpecCompliance/data_field_has_space
=== RUN   TestSpecCompliance/event_field_has_space
=== RUN   TestSpecCompliance/id_field_has_space
=== RUN   TestSpecCompliance/retry_field_has_space
=== RUN   TestSpecCompliance/multiline_data_continuation_has_space
=== RUN   TestSpecCompliance/round_trip_encode_decode
--- PASS: TestSpecCompliance (0.00s)
```

Fixes gin-gonic/gin#4280